### PR TITLE
chore: small code cleanup of client.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 .envrc
 test.json
+.idea

--- a/alternative_payment_types_get.go
+++ b/alternative_payment_types_get.go
@@ -1,6 +1,7 @@
 package toast
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 
@@ -114,7 +115,7 @@ func (r *AlternativePaymentTypesGetRequest) URL() *url.URL {
 
 func (r *AlternativePaymentTypesGetRequest) Do() (AlternativePaymentTypesGetResponseBody, error, *http.Response) {
 	// Create http request
-	req, err := r.client.NewRequest(nil, r)
+	req, err := r.client.NewRequest(context.Background(), r)
 	if err != nil {
 		return *r.NewResponseBody(), err, nil
 	}

--- a/dining_options_get.go
+++ b/dining_options_get.go
@@ -1,6 +1,7 @@
 package toast
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 
@@ -114,7 +115,7 @@ func (r *DiningOptionsGetRequest) URL() *url.URL {
 
 func (r *DiningOptionsGetRequest) Do() (DiningOptionsGetResponseBody, error, *http.Response) {
 	// Create http request
-	req, err := r.client.NewRequest(nil, r)
+	req, err := r.client.NewRequest(context.Background(), r)
 	if err != nil {
 		return *r.NewResponseBody(), err, nil
 	}

--- a/discounts_get.go
+++ b/discounts_get.go
@@ -1,6 +1,7 @@
 package toast
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 
@@ -118,7 +119,7 @@ func (r *DiscountsGetRequest) URL() *url.URL {
 
 func (r *DiscountsGetRequest) Do() (DiscountsGetResponseBody, error, *http.Response) {
 	// Create http request
-	req, err := r.client.NewRequest(nil, r)
+	req, err := r.client.NewRequest(context.Background(), r)
 	if err != nil {
 		return *r.NewResponseBody(), err, nil
 	}

--- a/login_post.go
+++ b/login_post.go
@@ -1,6 +1,7 @@
 package toast
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"time"
@@ -123,7 +124,7 @@ func (r *LoginPostRequest) URL() *url.URL {
 
 func (r *LoginPostRequest) Do() (LoginPostResponseBody, error) {
 	// Create http request
-	req, err := r.client.NewRequest(nil, r)
+	req, err := r.client.NewRequest(context.Background(), r)
 	if err != nil {
 		return *r.NewResponseBody(), err
 	}

--- a/menu_groups_get.go
+++ b/menu_groups_get.go
@@ -1,6 +1,7 @@
 package toast
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 
@@ -118,7 +119,7 @@ func (r *MenuGroupsGetRequest) URL() *url.URL {
 
 func (r *MenuGroupsGetRequest) Do() (MenuGroupsGetResponseBody, error, *http.Response) {
 	// Create http request
-	req, err := r.client.NewRequest(nil, r)
+	req, err := r.client.NewRequest(context.Background(), r)
 	if err != nil {
 		return *r.NewResponseBody(), err, nil
 	}

--- a/menu_item_get.go
+++ b/menu_item_get.go
@@ -1,6 +1,7 @@
 package toast
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 
@@ -115,7 +116,7 @@ func (r *MenuItemGetRequest) URL() *url.URL {
 
 func (r *MenuItemGetRequest) Do() (MenuItemGetResponseBody, error, *http.Response) {
 	// Create http request
-	req, err := r.client.NewRequest(nil, r)
+	req, err := r.client.NewRequest(context.Background(), r)
 	if err != nil {
 		return *r.NewResponseBody(), err, nil
 	}

--- a/menu_items_get.go
+++ b/menu_items_get.go
@@ -1,6 +1,7 @@
 package toast
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 
@@ -114,7 +115,7 @@ func (r *MenuItemsGetRequest) URL() *url.URL {
 
 func (r *MenuItemsGetRequest) Do() (MenuItemsGetResponseBody, error, *http.Response) {
 	// Create http request
-	req, err := r.client.NewRequest(nil, r)
+	req, err := r.client.NewRequest(context.Background(), r)
 	if err != nil {
 		return *r.NewResponseBody(), err, nil
 	}

--- a/omitempty/omitempty.go
+++ b/omitempty/omitempty.go
@@ -18,7 +18,7 @@ func MarshalJSON(obj interface{}) ([]byte, error) {
 		fs = append(fs, st.Field(i))
 	}
 
-	for i, _ := range fs {
+	for i := range fs {
 		if !fieldHasOmitEmpty(fs[i], "json") {
 			continue
 		}
@@ -56,7 +56,7 @@ func MarshalXML(obj interface{}, e *xml.Encoder, start xml.StartElement) error {
 		fs = append(fs, f)
 	}
 
-	for i, _ := range fs {
+	for i := range fs {
 		if !fieldHasOmitEmpty(fs[i], "xml") {
 			continue
 		}

--- a/orders_bulk_get.go
+++ b/orders_bulk_get.go
@@ -1,6 +1,7 @@
 package toast
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 
@@ -118,7 +119,7 @@ func (r *OrdersBulkGetRequest) URL() *url.URL {
 
 func (r *OrdersBulkGetRequest) Do() (OrdersBulkGetResponseBody, error, *http.Response) {
 	// Create http request
-	req, err := r.client.NewRequest(nil, r)
+	req, err := r.client.NewRequest(context.Background(), r)
 	if err != nil {
 		return *r.NewResponseBody(), err, nil
 	}

--- a/orders_get.go
+++ b/orders_get.go
@@ -1,6 +1,7 @@
 package toast
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 
@@ -116,7 +117,7 @@ func (r *OrdersGetRequest) URL() *url.URL {
 
 func (r *OrdersGetRequest) Do() (OrdersGetResponseBody, error, *http.Response) {
 	// Create http request
-	req, err := r.client.NewRequest(nil, r)
+	req, err := r.client.NewRequest(context.Background(), r)
 	if err != nil {
 		return *r.NewResponseBody(), err, nil
 	}

--- a/partner_restaurants_get.go
+++ b/partner_restaurants_get.go
@@ -1,6 +1,7 @@
 package toast
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"time"
@@ -64,7 +65,7 @@ func (r PartnerRestaurantsGetRequest) NewPathParams() *PartnerRestaurantsGetRequ
 	return &PartnerRestaurantsGetRequestPathParams{}
 }
 
-type PartnerRestaurantsGetRequestPathParams struct {}
+type PartnerRestaurantsGetRequestPathParams struct{}
 
 func (p *PartnerRestaurantsGetRequestPathParams) Params() map[string]string {
 	return map[string]string{}
@@ -130,7 +131,7 @@ func (r *PartnerRestaurantsGetRequest) URL() *url.URL {
 
 func (r *PartnerRestaurantsGetRequest) Do() (PartnerRestaurantsGetResponseBody, error, *http.Response) {
 	// Create http request
-	req, err := r.client.NewRequest(nil, r)
+	req, err := r.client.NewRequest(context.Background(), r)
 	if err != nil {
 		return *r.NewResponseBody(), err, nil
 	}

--- a/restaurant_get.go
+++ b/restaurant_get.go
@@ -1,6 +1,7 @@
 package toast
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"time"
@@ -134,7 +135,7 @@ func (r *RestaurantGetRequest) URL() *url.URL {
 
 func (r *RestaurantGetRequest) Do() (RestaurantGetResponseBody, error, *http.Response) {
 	// Create http request
-	req, err := r.client.NewRequest(nil, r)
+	req, err := r.client.NewRequest(context.Background(), r)
 	if err != nil {
 		return *r.NewResponseBody(), err, nil
 	}
@@ -154,4 +155,3 @@ func (r *RestaurantGetRequest) Do() (RestaurantGetResponseBody, error, *http.Res
 	resp, err := r.client.Do(req, responseBody)
 	return *responseBody, err, resp
 }
-

--- a/revenue_centers_get.go
+++ b/revenue_centers_get.go
@@ -1,6 +1,7 @@
 package toast
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 
@@ -114,7 +115,7 @@ func (r *RevenueCentersGetRequest) URL() *url.URL {
 
 func (r *RevenueCentersGetRequest) Do() (RevenueCentersGetResponseBody, error, *http.Response) {
 	// Create http request
-	req, err := r.client.NewRequest(nil, r)
+	req, err := r.client.NewRequest(context.Background(), r)
 	if err != nil {
 		return *r.NewResponseBody(), err, nil
 	}

--- a/sales_categories_get.go
+++ b/sales_categories_get.go
@@ -1,6 +1,7 @@
 package toast
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 
@@ -114,7 +115,7 @@ func (r *SalesCategoriesGetRequest) URL() *url.URL {
 
 func (r *SalesCategoriesGetRequest) Do() (SalesCategoriesGetResponseBody, error, *http.Response) {
 	// Create http request
-	req, err := r.client.NewRequest(nil, r)
+	req, err := r.client.NewRequest(context.Background(), r)
 	if err != nil {
 		return *r.NewResponseBody(), err, nil
 	}

--- a/setup_test.go
+++ b/setup_test.go
@@ -14,24 +14,11 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	var err error
-
 	baseURLString := os.Getenv("BASE_URL")
 	clientID := os.Getenv("CLIENT_ID")
 	clientSecret := os.Getenv("CLIENT_SECRET")
 	toastRestaurantExternalID := os.Getenv("TOAST_RESTAURANT_EXTERNAL_ID")
 	debug := os.Getenv("DEBUG")
-	if err != nil {
-		log.Fatal(err)
-	}
-	var baseURL *url.URL
-
-	if baseURLString != "" {
-		baseURL, err = url.Parse(baseURLString)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
 
 	client = asperion.NewClient(nil)
 	client.SetClientID(clientID)
@@ -41,10 +28,14 @@ func TestMain(m *testing.M) {
 		client.SetDebug(true)
 	}
 
-	if baseURL != nil {
-		client.SetBaseURL(*baseURL)
+	if baseURLString != "" {
+		if baseURL, err := url.Parse(baseURLString); err != nil {
+			log.Fatal(err)
+		} else {
+			client.SetBaseURL(*baseURL)
+		}
 	}
 
 	client.SetDisallowUnknownFields(true)
-	m.Run()
+	os.Exit(m.Run())
 }

--- a/tax_rates_get.go
+++ b/tax_rates_get.go
@@ -1,6 +1,7 @@
 package toast
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 
@@ -114,7 +115,7 @@ func (r *TaxRatesGetRequest) URL() *url.URL {
 
 func (r *TaxRatesGetRequest) Do() (TaxRatesGetResponseBody, error, *http.Response) {
 	// Create http request
-	req, err := r.client.NewRequest(nil, r)
+	req, err := r.client.NewRequest(context.Background(), r)
 	if err != nil {
 		return *r.NewResponseBody(), err, nil
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -16,13 +16,11 @@ import (
 var (
 	// register custom encoders
 	EncodeSchemaMarshaler = func(v reflect.Value) string {
-		marshaler, ok := v.Interface().(SchemaMarshaler)
-		if ok == true {
+		if marshaler, ok := v.Interface().(SchemaMarshaler); ok {
 			return marshaler.MarshalSchema()
 		}
 
-		stringer, ok := v.Interface().(fmt.Stringer)
-		if ok == true {
+		if stringer, ok := v.Interface().(fmt.Stringer); ok {
 			return stringer.String()
 		}
 
@@ -42,8 +40,7 @@ func AddQueryParamsToRequest(requestParams interface{}, req *http.Request, skipE
 	var err error
 	params := url.Values{}
 
-	to, ok := requestParams.(ToURLValues)
-	if ok == true {
+	if to, ok := requestParams.(ToURLValues); ok {
 		params, err = to.ToURLValues()
 		if err != nil {
 			return err


### PR DESCRIPTION
Did a small cleanup of the code, mostly of client.go. Also cleaned up some linting issues found by golangci-lint. There are a few notes on things I have seen:
- Plain getters / setters are not common / recommended in Go, it is more common to just expose the variables.
- pkg/errors package is abandoned since 2021, most functionality is in the native package
- context.Context should not be passed as nil